### PR TITLE
Add Jekyll build steps to workflow

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -32,6 +32,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Pages
+      - name: Setup Ruby
+  uses: ruby/setup-ruby@v1
+  with:
+    ruby-version: '3.0'
+
+- name: Install Jekyll and Bundler
+  run: |
+    gem install bundler jekyll
+
+- name: Build Jekyll site
+  run: |
+    bundle exec jekyll build
         uses: actions/configure-pages@v5
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
This pull request adds steps to the GitHub Actions workflow to integrate Jekyll into the GitHub Pages deployment process. It includes steps to install Ruby, Jekyll, and Bundler, and to build the Jekyll site before deploying it to GitHub Pages.